### PR TITLE
If it doesn't already exist, copy libVuforia.so whenever we build and run the app

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/SplashActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/SplashActivity.java
@@ -119,13 +119,17 @@ public class SplashActivity extends Activity
 
     private void showLibNotOnSdcardDialog()
     {
-        String msg = "Please copy it to the FIRST folder on the phone's storage.<br><br>" +
+        String msg = "libVuforia.so should have been copied to the phone the first time you deployed " +
+                "this app from Android Studio.<br><br>" +
+
+                "Re-deploying the app through Android Studio should fix the issue. Make sure to only " +
+                "have a single Android device connected, or the file will fail to copy.<br><br>" +
+
+                "If that doesn't work or isn't an option, you can copy libVuforia.so to the FIRST folder" +
+                " on the phone's storage yourself.<br><br>" +
 
                 "<a href='https://github.com/OpenFTC/OpenFTC-app-turbo/blob/5b706b920252ed810038849e4c52c7c5c89e56ef/doc/libVuforia.so?raw=true'>" +
-                "You can find libVuforia.so in the 'doc' folder of the OpenFTC repository</a>.<br><br>" +
-
-                "You can copy it from your laptop, or download it to your phone from the above link " +
-                "and use a file manager app to move it to the correct location.";
+                "You can find it in the 'doc' folder of the OpenFTC repository</a>.";
 
         AlertDialog dialog = new AlertDialog.Builder(this)
         .setTitle("libVuforia.so not found!")

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -127,6 +127,8 @@ task pushVuforiaIfNecessary(type: Exec) {
 
             def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
 
+            println "Output of vuforia check: ${vuforiaCheckOutput()}"
+
             if(vuforiaCheckOutput().contains("No such file")) {
                 println "libVuforia.so not found on phone. Pushing."
                 commandLine pushVuforiaCommand

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -128,6 +128,7 @@ task pushVuforiaIfNecessary(type: Exec) {
             def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
 
             if(vuforiaCheckOutput().contains("No such file")) {
+                println "libVuforia.so not found on phone. Pushing."
                 commandLine pushVuforiaCommand
             } else if(vuforiaCheckExitedCleanly) {
                 commandLine 'echo', 'Skipping, libVuforia already exists'

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -108,8 +108,25 @@ android {
     }
 }
 
+
+def adbLocation = android.getAdbExecutable().absolutePath
+
+task setupFirstFolder(type: Exec) {
+    def createFirstFolderCommand = [adbLocation, 'shell', 'mkdir', '-p', '/sdcard/FIRST']
+    commandLine createFirstFolderCommand
+
+    doLast {
+        exec {
+            def mtpBroadcastCommand = [adbLocation, 'shell', 'am', 'broadcast', '-a',
+                                       'android.intent.action.MEDIA_SCANNER_SCAN_FILE',
+                                        '-d', 'file:/sdcard/FIRST']
+            commandLine mtpBroadcastCommand
+        }
+    }
+}
+
 task pushVuforiaIfNecessary(type: Exec) {
-    def adbLocation = android.getAdbExecutable().absolutePath
+    dependsOn(setupFirstFolder)
     def checkVuforiaCommand = [adbLocation, 'shell', 'ls', '/sdcard/FIRST/libVuforia.so']
 
     commandLine checkVuforiaCommand
@@ -132,7 +149,7 @@ task pushVuforiaIfNecessary(type: Exec) {
             def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
             def combinedCheckOutput = "${vuforiaCheckOutput()}\n${vuforiaCheckError()}"
             if(combinedCheckOutput.contains("No such file")) {
-                println "libVuforia.so not found on phone. Pushing."
+                println "libVuforia.so not found on phone. Pushing!"
                 commandLine pushVuforiaCommand
             } else if(vuforiaCheckExitedCleanly) {
                 commandLine 'echo', 'Skipping, libVuforia already exists.'

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -114,21 +114,25 @@ task pushVuforiaIfNecessary(type: Exec) {
 
     commandLine checkVuforiaCommand
     standardOutput = new ByteArrayOutputStream()
+    ignoreExitValue = true
 
-    ext.checkOutput = {
+    ext.vuforiaCheckOutput = {
         return standardOutput.toString()
     }
 
     doLast {
+        def vuforiaCheckExitedCleanly = (execResult.exitValue == 0)
         exec {
             workingDir '../doc/'
 
             def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
 
-            if(checkOutput().contains("No such file")) {
+            if(vuforiaCheckOutput().contains("No such file")) {
                 commandLine pushVuforiaCommand
+            } else if(vuforiaCheckExitedCleanly) {
+                commandLine 'echo', 'Skipping, libVuforia already exists'
             } else {
-                commandLine 'echo', 'libVuforia already exists on phone'
+                commandLine 'echo', 'Failed to connect to phone'
             }
         }
     }

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -109,7 +109,8 @@ android {
 }
 
 task pushVuforiaIfNecessary(type: Exec) {
-    def checkVuforiaCommand = ['adb', 'shell', 'ls', '/sdcard/FIRST/libVuforia.so']
+    def adbLocation = android.getAdbExecutable().absolutePath
+    def checkVuforiaCommand = [adbLocation, 'shell', 'ls', '/sdcard/FIRST/libVuforia.so']
 
     commandLine checkVuforiaCommand
     standardOutput = new ByteArrayOutputStream()
@@ -122,7 +123,7 @@ task pushVuforiaIfNecessary(type: Exec) {
         exec {
             workingDir '../doc/'
 
-            def pushVuforiaCommand = ['adb', 'push', 'libVuforia.so', '/sdcard/FIRST']
+            def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
 
             if(checkOutput().contains("No such file")) {
                 commandLine pushVuforiaCommand

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -114,10 +114,14 @@ task pushVuforiaIfNecessary(type: Exec) {
 
     commandLine checkVuforiaCommand
     standardOutput = new ByteArrayOutputStream()
+    errorOutput = new ByteArrayOutputStream()
     ignoreExitValue = true
 
     ext.vuforiaCheckOutput = {
         return standardOutput.toString()
+    }
+    ext.vuforiaCheckError = {
+        return errorOutput.toString()
     }
 
     doLast {
@@ -126,16 +130,22 @@ task pushVuforiaIfNecessary(type: Exec) {
             workingDir '../doc/'
 
             def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
-
-            println "Output of vuforia check: ${vuforiaCheckOutput()}"
-
-            if(vuforiaCheckOutput().contains("No such file")) {
+            def combinedCheckOutput = "${vuforiaCheckOutput()}\n${vuforiaCheckError()}"
+            if(combinedCheckOutput.contains("No such file")) {
                 println "libVuforia.so not found on phone. Pushing."
                 commandLine pushVuforiaCommand
             } else if(vuforiaCheckExitedCleanly) {
-                commandLine 'echo', 'Skipping, libVuforia already exists'
+                commandLine 'echo', 'Skipping, libVuforia already exists.'
+            } else if(combinedCheckOutput.contains("no devices")) {
+                commandLine 'echo', 'Skipping, no device to push to.'
+            } else if(combinedCheckOutput.contains("more than one")) {
+                commandLine 'echo', 'Multiple Android devices found.'
+                logger.warn('\nUnable to check for libVuforia.so when multiple devices are connected.')
+                logger.warn('If any connected devices do not have libVuforia.so already, they will display an error when the app starts.')
+                logger.warn('If this occurs, you can simply deploy the app from Android Studio with only a single device connected.\n')
             } else {
-                commandLine 'echo', 'Failed to connect to phone'
+                println combinedCheckOutput
+                commandLine 'echo', 'Failed to connect to phone.'
             }
         }
     }

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -108,6 +108,39 @@ android {
     }
 }
 
+task pushVuforiaIfNecessary(type: Exec) {
+    def checkVuforiaCommand = ['adb', 'shell', 'ls', '/sdcard/FIRST/libVuforia.so']
+
+    commandLine checkVuforiaCommand
+    standardOutput = new ByteArrayOutputStream()
+
+    ext.checkOutput = {
+        return standardOutput.toString()
+    }
+
+    doLast {
+        exec {
+            workingDir '../doc/'
+
+            def pushVuforiaCommand = ['adb', 'push', 'libVuforia.so', '/sdcard/FIRST']
+
+            if(checkOutput().contains("No such file")) {
+                commandLine pushVuforiaCommand
+            } else {
+                commandLine 'echo', 'libVuforia already exists on phone'
+            }
+        }
+    }
+}
+
+tasks.whenTaskAdded { task ->
+    // I chose this task because it is never UP-TO-DATE. We should verify that that hasn't changed,
+    // whenever we update the Android Gradle plugin.
+    if (task.name == 'validateSigningOpenftcDebug') {
+        task.dependsOn(pushVuforiaIfNecessary)
+    }
+}
+
 repositories {
     flatDir {
         dirs rootProject.file('libs')


### PR DESCRIPTION
Closes #48. This would also remove the need for the ability for the app to download the file itself.