### PR TITLE
Move vuforia-pushing code to new Gradle script

### DIFF
--- a/OpenFTC/openftc-tasks.gradle
+++ b/OpenFTC/openftc-tasks.gradle
@@ -1,0 +1,67 @@
+
+def adbLocation = android.getAdbExecutable().absolutePath
+
+task setupFirstFolder(type: Exec) {
+    def createFirstFolderCommand = [adbLocation, 'shell', 'mkdir', '-p', '/sdcard/FIRST']
+    commandLine createFirstFolderCommand
+
+    doLast {
+        exec {
+            def mtpBroadcastCommand = [adbLocation, 'shell', 'am', 'broadcast', '-a',
+                                       'android.intent.action.MEDIA_SCANNER_SCAN_FILE',
+                                       '-d', 'file:/sdcard/FIRST']
+            commandLine mtpBroadcastCommand
+        }
+    }
+}
+
+task pushVuforiaIfNecessary(type: Exec) {
+    dependsOn(setupFirstFolder)
+    def checkVuforiaCommand = [adbLocation, 'shell', 'ls', '/sdcard/FIRST/libVuforia.so']
+
+    commandLine checkVuforiaCommand
+    standardOutput = new ByteArrayOutputStream()
+    errorOutput = new ByteArrayOutputStream()
+    ignoreExitValue = true
+
+    ext.vuforiaCheckOutput = {
+        return standardOutput.toString()
+    }
+    ext.vuforiaCheckError = {
+        return errorOutput.toString()
+    }
+
+    doLast {
+        def vuforiaCheckExitedCleanly = (execResult.exitValue == 0)
+        exec {
+            workingDir '../doc/'
+
+            def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
+            def combinedCheckOutput = "${vuforiaCheckOutput()}\n${vuforiaCheckError()}"
+            if(combinedCheckOutput.contains("No such file")) {
+                println "libVuforia.so not found on phone. Pushing!"
+                commandLine pushVuforiaCommand
+            } else if(vuforiaCheckExitedCleanly) {
+                commandLine 'echo', 'Skipping, libVuforia already exists.'
+            } else if(combinedCheckOutput.contains("no devices")) {
+                commandLine 'echo', 'Skipping, no device to push to.'
+            } else if(combinedCheckOutput.contains("more than one")) {
+                commandLine 'echo', 'Multiple Android devices found.'
+                logger.warn('\nUnable to check for libVuforia.so when multiple devices are connected.')
+                logger.warn('If any connected devices do not have libVuforia.so already, they will display an error when the app starts.')
+                logger.warn('If this occurs, you can simply deploy the app from Android Studio with only a single device connected.\n')
+            } else {
+                println combinedCheckOutput
+                commandLine 'echo', 'Failed to connect to phone.'
+            }
+        }
+    }
+}
+
+tasks.whenTaskAdded { task ->
+    // I chose this task because it is never shown as "UP-TO-DATE" when you run Gradle without changing anything.
+    // We should verify that that hasn't changed whenever we update the Android Gradle plugin.
+    if (task.name == 'validateSigningOpenftcDebug') {
+        task.dependsOn(pushVuforiaIfNecessary)
+    }
+}

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -90,7 +90,8 @@ android {
     }
 
     // Selecting a release variant will prompt teams to set up a signing key. Now that there's
-    // a reason to select other variants, better to filter out the ones that will confuse teams.
+    // a reason to select other variants (the stock feature of OpenFTC), it's better to filter out
+    // the ones that will confuse teams.
     variantFilter { variant ->
         if (variant.buildType.name == "release") {
             setIgnore(true)
@@ -108,77 +109,12 @@ android {
     }
 }
 
-
-def adbLocation = android.getAdbExecutable().absolutePath
-
-task setupFirstFolder(type: Exec) {
-    def createFirstFolderCommand = [adbLocation, 'shell', 'mkdir', '-p', '/sdcard/FIRST']
-    commandLine createFirstFolderCommand
-
-    doLast {
-        exec {
-            def mtpBroadcastCommand = [adbLocation, 'shell', 'am', 'broadcast', '-a',
-                                       'android.intent.action.MEDIA_SCANNER_SCAN_FILE',
-                                        '-d', 'file:/sdcard/FIRST']
-            commandLine mtpBroadcastCommand
-        }
-    }
-}
-
-task pushVuforiaIfNecessary(type: Exec) {
-    dependsOn(setupFirstFolder)
-    def checkVuforiaCommand = [adbLocation, 'shell', 'ls', '/sdcard/FIRST/libVuforia.so']
-
-    commandLine checkVuforiaCommand
-    standardOutput = new ByteArrayOutputStream()
-    errorOutput = new ByteArrayOutputStream()
-    ignoreExitValue = true
-
-    ext.vuforiaCheckOutput = {
-        return standardOutput.toString()
-    }
-    ext.vuforiaCheckError = {
-        return errorOutput.toString()
-    }
-
-    doLast {
-        def vuforiaCheckExitedCleanly = (execResult.exitValue == 0)
-        exec {
-            workingDir '../doc/'
-
-            def pushVuforiaCommand = [adbLocation, 'push', 'libVuforia.so', '/sdcard/FIRST']
-            def combinedCheckOutput = "${vuforiaCheckOutput()}\n${vuforiaCheckError()}"
-            if(combinedCheckOutput.contains("No such file")) {
-                println "libVuforia.so not found on phone. Pushing!"
-                commandLine pushVuforiaCommand
-            } else if(vuforiaCheckExitedCleanly) {
-                commandLine 'echo', 'Skipping, libVuforia already exists.'
-            } else if(combinedCheckOutput.contains("no devices")) {
-                commandLine 'echo', 'Skipping, no device to push to.'
-            } else if(combinedCheckOutput.contains("more than one")) {
-                commandLine 'echo', 'Multiple Android devices found.'
-                logger.warn('\nUnable to check for libVuforia.so when multiple devices are connected.')
-                logger.warn('If any connected devices do not have libVuforia.so already, they will display an error when the app starts.')
-                logger.warn('If this occurs, you can simply deploy the app from Android Studio with only a single device connected.\n')
-            } else {
-                println combinedCheckOutput
-                commandLine 'echo', 'Failed to connect to phone.'
-            }
-        }
-    }
-}
-
-tasks.whenTaskAdded { task ->
-    // I chose this task because it is never UP-TO-DATE. We should verify that that hasn't changed,
-    // whenever we update the Android Gradle plugin.
-    if (task.name == 'validateSigningOpenftcDebug') {
-        task.dependsOn(pushVuforiaIfNecessary)
-    }
-}
-
 repositories {
     flatDir {
         dirs rootProject.file('libs')
     }
 }
+
+apply from: "$rootProject.projectDir/OpenFTC/openftc-tasks.gradle"
+
 apply from: 'build.release.gradle'


### PR DESCRIPTION
I really uglified `build.common.gradle` a bunch when I made the feature that pushes libVuforia.so to the robot if it doesn't already exist. This PR moves all of the ugliness to its own file.