### PR TITLE
Show OpenFTC version on the RC inspection screen of the DS

### DIFF
--- a/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcEventLoopBase.java
+++ b/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcEventLoopBase.java
@@ -840,7 +840,10 @@ public abstract class FtcEventLoopBase implements EventLoop {
      */
     protected void handleCommandRequestInspectionReport() {
         InspectionState inspectionState = new InspectionState();
-        inspectionState.initializeLocal();
+
+        // Modified for OpenFTC: Call new initializeForDs method (includes OpenFTC version)
+        inspectionState.initializeForDs();
+
         String serialized = inspectionState.serialize();
         networkConnectionHandler.sendCommand(new Command(CommandList.CMD_REQUEST_INSPECTION_REPORT_RESP, serialized));
     }

--- a/Inspection/src/main/java/org/firstinspires/inspection/InspectionState.java
+++ b/Inspection/src/main/java/org/firstinspires/inspection/InspectionState.java
@@ -92,6 +92,12 @@ public class InspectionState {
     public InspectionState() {
     }
 
+    // Modified for OpenFTC: If this InspectionState will be sent to the DS, show that OpenFTC is installed)
+    public void initializeForDs() {
+        initializeLocal();
+        this.robotControllerVersion = robotControllerVersion.concat(" (OpenFTC " + org.openftc.BuildConfig.VERSION_NAME + ")");
+    }
+
     public void initializeLocal() {
         DeviceNameManager nameManager = DeviceNameManager.getInstance();
         StartResult startResult = nameManager.start();

--- a/OpenFTC/build.gradle
+++ b/OpenFTC/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 19
         versionCode 3
-        versionName "1.2 SNAPSHOT"
+        versionName "1.2SS"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
The local version of the RC inspection activity has a dedicated OpenFTC section, so this PR doesn't change that. 

Here's what it looks like on a ZTE-Speed sized phone: 
![image](https://user-images.githubusercontent.com/10224994/34657722-2eacb356-f3f7-11e7-956b-592363da4855.png)

  