### PR TITLE
Add a new dialog to alert new users that OpenRC is not competition-legal

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
@@ -238,6 +238,10 @@ public class FtcRobotControllerActivity extends Activity {
             UiUtils.showDsAppInstalledDialog(this);
         }
 
+        if(BuildConfig.IS_OPENRC && !Utils.hasAcknowledgedLegalityStatus()) {
+            UiUtils.showLegalityAcknowlegementDialog(this);
+        }
+
         ThemedActivity.appAppThemeToActivity(getTag(), this); // do this way instead of inherit to help AppInventor
 
         Assert.assertTrue(FtcRobotControllerWatchdogService.isFtcRobotControllerActivity(AppUtil.getInstance().getRootActivity()));

--- a/OpenRC/build.gradle
+++ b/OpenRC/build.gradle
@@ -26,4 +26,5 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    compile project(path: ':RobotCore')
 }

--- a/OpenRC/src/main/java/org/openftc/rc/UiUtils.java
+++ b/OpenRC/src/main/java/org/openftc/rc/UiUtils.java
@@ -45,29 +45,35 @@ public class UiUtils {
     }
 
     public static void showOpenRcSummary(final Activity activity) {
-        LayoutInflater inflater = LayoutInflater.from(activity);
-        View view = inflater.inflate(R.layout.about_openrc_layout, null);
+        final LayoutInflater inflater = LayoutInflater.from(activity);
+        final View view = inflater.inflate(R.layout.about_openrc_layout, null);
 
-        AlertDialog.Builder builder;
-        builder = new AlertDialog.Builder(activity);
-        builder.setCancelable(false);
+        final TextView textView = (TextView)view.findViewById(R.id.about_openrc_textview);
+        final SpannableString aboutText = new SpannableString(activity.getText(R.string.openRcSummary));
+        Linkify.addLinks(aboutText, Linkify.WEB_URLS);
 
-        builder.setTitle("About OpenRC")
+        textView.setText(aboutText);
+        textView.setMovementMethod(LinkMovementMethod.getInstance());
+
+        new AlertDialog.Builder(activity)
+                .setCancelable(false)
+                .setTitle("About OpenRC")
                 .setView(view)
-                .setPositiveButton("Ok", new DialogInterface.OnClickListener() {
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
 
                     }
                 })
                 .setIcon(R.drawable.ic_info_outline)
                 .show();
+
     }
 
     public static void showLegalityAcknowlegementDialog(final Activity activity) {
-        SpannableString dialogText = new SpannableString(activity.getText(R.string.openRcLegalityWarning));
+        final SpannableString dialogText = new SpannableString(activity.getText(R.string.openRcLegalityWarning));
         Linkify.addLinks(dialogText, Linkify.WEB_URLS);
 
-        AlertDialog legalityDialog = new AlertDialog.Builder(activity)
+        final AlertDialog legalityDialog = new AlertDialog.Builder(activity)
                 .setMessage(dialogText)
                 .setPositiveButton("Acknowledged.", new DialogInterface.OnClickListener() {
                     @Override

--- a/OpenRC/src/main/java/org/openftc/rc/UiUtils.java
+++ b/OpenRC/src/main/java/org/openftc/rc/UiUtils.java
@@ -6,8 +6,12 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.Html;
+import android.text.SpannableString;
+import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 public class UiUtils {
     public static void showDsAppInstalledDialog(final Activity activity) {
@@ -57,5 +61,29 @@ public class UiUtils {
                 })
                 .setIcon(R.drawable.ic_info_outline)
                 .show();
+    }
+
+    public static void showLegalityAcknowlegementDialog(final Activity activity) {
+        SpannableString dialogText = new SpannableString(activity.getText(R.string.openRcLegalityWarning));
+        Linkify.addLinks(dialogText, Linkify.WEB_URLS);
+
+        AlertDialog legalityDialog = new AlertDialog.Builder(activity)
+                .setMessage(dialogText)
+                .setPositiveButton("Acknowledged.", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Utils.setLegalityAcknowledgementStatus(true);
+                    }
+                })
+                .setNegativeButton("Tell me again.", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Utils.setLegalityAcknowledgementStatus(false);
+                    }
+                })
+                .create();
+        legalityDialog.show();
+
+        ((TextView)legalityDialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance());
     }
 }

--- a/OpenRC/src/main/java/org/openftc/rc/Utils.java
+++ b/OpenRC/src/main/java/org/openftc/rc/Utils.java
@@ -1,8 +1,15 @@
 package org.openftc.rc;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 
+import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
+
 public class Utils {
+    private static String openRcPreferencesFilename = AppUtil.getDefContext().getString(R.string.openRcPreferencesFile);
+    private static SharedPreferences openRcPrefs = AppUtil.getDefContext().getSharedPreferences(openRcPreferencesFilename, Context.MODE_PRIVATE);
+
     public static boolean isFtcDriverStationInstalled(PackageManager packageManager) {
         try {
             packageManager.getPackageInfo("com.qualcomm.ftcdriverstation", 0);
@@ -10,5 +17,15 @@ public class Utils {
         } catch (PackageManager.NameNotFoundException e) {
             return false;
         }
+    }
+
+    public static boolean hasAcknowledgedLegalityStatus() {
+        return openRcPrefs.getBoolean(AppUtil.getDefContext().getString(R.string.acknowledgedLegalityPrefKey), false);
+    }
+
+    public static void setLegalityAcknowledgementStatus(boolean legalityAcknowledged) {
+        openRcPrefs.edit().
+                putBoolean(AppUtil.getDefContext().getString(R.string.acknowledgedLegalityPrefKey), legalityAcknowledged)
+                .apply();
     }
 }

--- a/OpenRC/src/main/res/layout/about_openrc_layout.xml
+++ b/OpenRC/src/main/res/layout/about_openrc_layout.xml
@@ -1,13 +1,14 @@
 <ScrollView
+
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
 
     <TextView
+        android:id="@+id/about_openrc_textview"
         android:layout_width="match_parent"
         android:layout_margin="10dp"
         android:layout_height="wrap_content"
-        android:textSize="15dp"
-        android:text="@string/openRcSummary"/>
+        android:textSize="15sp" />
 
 </ScrollView>

--- a/OpenRC/src/main/res/values/strings.xml
+++ b/OpenRC/src/main/res/values/strings.xml
@@ -5,6 +5,16 @@
         path to install a competition-legal version of the app. \n\nThe GDC has ruled that OpenRC is not legal for
         competition use, and a user acknowledged this fact the first time they launched this app.\n\nFor more information
         about OpenRC and the OpenFTC community responsible for it, please see http://openftc.org/OpenRC</string>
+    <string name="openRcLegalityWarning">
+        OpenRC has been ruled ILLEGAL for competition use.
+
+        \n\nUse Android Studio to switch to the competition-legal stock build variant before going to a competition.
+
+        \n\nhttp://openftc.org/OpenRC/legality
+    </string>
+
+    <string name="openRcPreferencesFile">org.openftc.openrc.preferences</string>
+    <string name="acknowledgedLegalityPrefKey">acknowledged_legality</string>
 
     <!-- Strings for Line Wrap preference -->
     <string name="prefcat_logging_key">logging_category</string>

--- a/OpenRC/src/main/res/values/strings.xml
+++ b/OpenRC/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
         community. The goal of OpenRC is to improve the development experience for teams, while providing a quick-and-easy
         path to install a competition-legal version of the app.
 
-        \n\nThe GDC has ruled that OpenRC is NOT legal for competition use, and a user acknowledged this fact the first
+        \n\nThe GDC has ruled that OpenRC is NOT legal for competition use, and the user acknowledged this fact the first
         time they launched this app.
 
         \n\nFor more information about OpenRC and the OpenFTC community responsible for it, please visit http://openftc.org/OpenRC

--- a/OpenRC/src/main/res/values/strings.xml
+++ b/OpenRC/src/main/res/values/strings.xml
@@ -1,10 +1,16 @@
 <resources>
     <string name="app_name">OpenRC</string>
-    <string name="openRcSummary">OpenRC is a modified version of the ftc_app software created by members of the OpenFTC
+    <string name="openRcSummary">
+        OpenRC is a modified version of the ftc_app software created by members of the OpenFTC
         community. The goal of OpenRC is to improve the development experience for teams, while providing a quick-and-easy
-        path to install a competition-legal version of the app. \n\nThe GDC has ruled that OpenRC is not legal for
-        competition use, and a user acknowledged this fact the first time they launched this app.\n\nFor more information
-        about OpenRC and the OpenFTC community responsible for it, please see http://openftc.org/OpenRC</string>
+        path to install a competition-legal version of the app.
+
+        \n\nThe GDC has ruled that OpenRC is NOT legal for competition use, and a user acknowledged this fact the first
+        time they launched this app.
+
+        \n\nFor more information about OpenRC and the OpenFTC community responsible for it, please visit http://openftc.org/OpenRC
+    </string>
+
     <string name="openRcLegalityWarning">
         OpenRC has been ruled ILLEGAL for competition use.
 


### PR DESCRIPTION
The dialog will show up every launch until the user acknowledges it.

In addition to this new dialog, I made the link to the OpenRC website in the "About OpenRC" dialog clickable. The actual text of this dialog has been changed as well, to reflect the legality ruling.