### PR TITLE
Vuforia improvements

### DIFF
--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/external/navigation/VuforiaLocalizer.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/external/navigation/VuforiaLocalizer.java
@@ -171,7 +171,10 @@ public interface VuforiaLocalizer {
         }
     }
 
-    ;
+    /***
+     * Closes Vuforia the same way that it is closed at the end of an OpMode
+     */
+    void close();
 
     /**
      * {@link Parameters} provides configuration information for instantiating the Vuforia localizer

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/opmode/OpModeManagerImpl.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/opmode/OpModeManagerImpl.java
@@ -385,6 +385,11 @@ public class OpModeManagerImpl implements OpModeServices, OpModeManagerNotifier 
             @Override
             public void run() {
                 activeOpMode.stop();
+                if(!(activeOpMode instanceof DefaultOpMode))
+                {
+                    activeOpMode.telemetry.addLine("Status: OpMode terminated; awaiting switch to StopRobot");
+                    activeOpMode.telemetry.update();
+                }
             }
         });
         synchronized (this.listeners) {

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/opmode/OpModeManagerImpl.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/opmode/OpModeManagerImpl.java
@@ -385,11 +385,6 @@ public class OpModeManagerImpl implements OpModeServices, OpModeManagerNotifier 
             @Override
             public void run() {
                 activeOpMode.stop();
-                if(!(activeOpMode instanceof DefaultOpMode))
-                {
-                    activeOpMode.telemetry.addLine("Status: OpMode terminated; awaiting switch to StopRobot");
-                    activeOpMode.telemetry.update();
-                }
             }
         });
         synchronized (this.listeners) {

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/vuforia/VuforiaLocalizerImpl.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/vuforia/VuforiaLocalizerImpl.java
@@ -213,7 +213,7 @@ public class VuforiaLocalizerImpl implements VuforiaLocalizer {
         startAR();
     }
 
-    protected void close()
+    public void close()
     // Must be idempotent. Callable from ANY thread
     {
         stopAR();
@@ -534,10 +534,10 @@ public class VuforiaLocalizerImpl implements VuforiaLocalizer {
     protected void stopAR() {
         synchronized (startStopLock) {
             this.wantCamera = false;
+            removeGlSurface();
             stopCamera();
             destroyTrackables();
             deinitTracker();
-            removeGlSurface();
             Vuforia.deinit();
         }
     }


### PR DESCRIPTION
This PR does two things:

1) Make the Vuforia close method public so it can be called from an OpMode
2) Alter the order in which things happen in that close method so that the camera view is removed immediately, (providing a better user-experience) instead of waiting for everything else to close before removing the camera view.